### PR TITLE
Update lume-2.md (fix typo)

### DIFF
--- a/posts/lume-2.md
+++ b/posts/lume-2.md
@@ -275,7 +275,7 @@ used (`imagick` in the `imagick` plugin, `imageTransform` in the
 `image_transform` plugin).
 
 This change affects also to the `picture` plugin that now uses the
-`image-transform` attribute instead of `imagick`.
+`transform-images` attribute instead of `imagick`.
 
 See the
 [docs for `image_transform`](https://lume.land/plugins/transform_images/).


### PR DESCRIPTION
correct `picture` plugin attribute to `transform-images`

Did an upgrade following the blog and my image gallery was broken. Checked the [picture plugin docs](https://lume.land/plugins/picture/#configuring-the-img-container) to find the correct attribute.

Thanks for all of your work with this project. 